### PR TITLE
Release 1.0.165

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = joplin
 	pkgdesc = Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
-	pkgver = 1.0.161
+	pkgver = 1.0.165
 	pkgrel = 1
 	url = https://joplin.cozic.net
 	arch = x86_64
@@ -18,11 +18,11 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = https://github.com/laurent22/joplin/archive/v1.0.161.zip
-	sha256sums = 60f203c91887c692bf09d4f89c905a08d0aa7e42944983332530405c0e1449c0
+	source = https://github.com/laurent22/joplin/archive/v1.0.165.zip
+	sha256sums = 1d5676ded18ae55d31d0dfc8e46a1646a045df94d9c169e68451536ebd9cb653
 	sha256sums = 41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d
 	sha256sums = 5245da6f5f647d49fbe044b747994c9f5a8e98b3c2cd02757dd189426a677276
-	sha256sums = 7aedc76da32f5bc8b7b015c3a87924e9bd6661e3051c84245e965e97348173b6
+	sha256sums = a24bd0c1446bbcc88648fe22dc3e1fbbf7029919336504a833a2fee74e64f6a9
 
 pkgname = joplin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # https://github.com/masterkorp/joplin-pkgbuild
 
 pkgname=joplin
-pkgver=1.0.161
+pkgver=1.0.165
 pkgrel=1
 pkgdesc="Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS."
 arch=("x86_64" "i686")
@@ -15,10 +15,10 @@ url="https://joplin.cozic.net"
 license=("MIT")
 source=("${pkgname}.desktop" "joplin-desktop.sh" "joplin.sh"
         "https://github.com/laurent22/joplin/archive/v${pkgver}.zip")
-sha256sums=('60f203c91887c692bf09d4f89c905a08d0aa7e42944983332530405c0e1449c0'
+sha256sums=('1d5676ded18ae55d31d0dfc8e46a1646a045df94d9c169e68451536ebd9cb653'
             '41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d'
             '5245da6f5f647d49fbe044b747994c9f5a8e98b3c2cd02757dd189426a677276'
-            '7aedc76da32f5bc8b7b015c3a87924e9bd6661e3051c84245e965e97348173b6')
+            'a24bd0c1446bbcc88648fe22dc3e1fbbf7029919336504a833a2fee74e64f6a9')
 
 build() {
 

--- a/joplin.desktop
+++ b/joplin.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0.161
+Version=1.0.165
 Name=Joplin
 Comment=Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
 Exec=/usr/bin/joplin-desktop


### PR DESCRIPTION
The AUR is out dated. I tried to change the version numbers and the sha256sums, but during the `makepkg -fc` I got some errors about npm and sqlite. Considering that I'm new to Arch and AUR, I'm not sure if the problem is about the changes I made or about the npm installation on my machine. Regardless, here are my changes, hope at least I have reduce some of the work for you.