### PR TITLE
Release 1.0.165

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # https://github.com/masterkorp/joplin-pkgbuild
 
 pkgname=joplin
-pkgver=1.0.161
+pkgver=1.0.165
 pkgrel=1
 pkgdesc="Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS."
 arch=("x86_64" "i686")
@@ -15,10 +15,10 @@ url="https://joplin.cozic.net"
 license=("MIT")
 source=("${pkgname}.desktop" "joplin-desktop.sh" "joplin.sh"
         "https://github.com/laurent22/joplin/archive/v${pkgver}.zip")
-sha256sums=('60f203c91887c692bf09d4f89c905a08d0aa7e42944983332530405c0e1449c0'
+sha256sums=('1d5676ded18ae55d31d0dfc8e46a1646a045df94d9c169e68451536ebd9cb653'
             '41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d'
             '5245da6f5f647d49fbe044b747994c9f5a8e98b3c2cd02757dd189426a677276'
-            '7aedc76da32f5bc8b7b015c3a87924e9bd6661e3051c84245e965e97348173b6')
+            'a24bd0c1446bbcc88648fe22dc3e1fbbf7029919336504a833a2fee74e64f6a9')
 
 build() {
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -65,7 +65,7 @@ package() {
   install -m755 joplin-desktop.sh "${pkgdir}/usr/bin/joplin-desktop"
   install -m755 joplin.sh "${pkgdir}/usr/bin/joplin"
 
-  install -Dm644 ../joplin.desktop ${pkgdir}/usr/share/applications/joplin.desktop
+  install -Dm644 joplin.desktop "${pkgdir}/usr/share/applications/joplin.desktop"
   install -Dm644 "${srcdir}/${pkgname}-${pkgver}/LICENSE" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -35,10 +35,10 @@ build() {
     "${srcdir}/${pkgname}-${pkgver}/CliClient/build/"
   rsync -a --delete "${srcdir}/${pkgname}-${pkgver}/ReactNativeClient/lib/" \
     "${srcdir}/${pkgname}-${pkgver}/CliClient/build/lib"
-  cp "package.json" "${srcdir}/${pkgname}-${pkgver}/CliClient/build"
-  cp "package-lock.json" "${srcdir}/${pkgname}-${pkgver}/CliClient/build"
 
   cd "${srcdir}/${pkgname}-${pkgver}/CliClient/build/"
+  # NOTE: Manually forcing sqlite 4.0.7 for node v12, remove later on
+  npm install sqlite3@4.0.7
   npm install
 
   # Electron App

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,7 @@ depends=("nodejs" "gconf")
 provides=("joplin" "joplin-cli")
 url="https://joplin.cozic.net"
 license=("MIT")
-source=("${pkgname}.desktop" "joplin-desktop.sh" "joplin.sh"
+source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
         "https://github.com/laurent22/joplin/archive/v${pkgver}.zip")
 sha256sums=('1d5676ded18ae55d31d0dfc8e46a1646a045df94d9c169e68451536ebd9cb653'
             '41bfdc95a6ee285eb644d05eb3bded72a83950d4720c3c8058ddd3c605cd625d'

--- a/joplin.desktop
+++ b/joplin.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=1.0.161
+Version=1.0.165
 Name=Joplin
 Comment=Joplin - a note taking and to-do application with synchronization capabilities for Windows, macOS, Linux, Android and iOS.
 Exec=/usr/bin/joplin-desktop


### PR DESCRIPTION
This updates to [1.0.165](https://github.com/laurent22/joplin/releases/tag/v1.0.165),
- Fixes desktop file
- Fixes sqlite dependency issue on node v12
- Closes #28 
- Closes #26 