### PR TITLE
fix: missing joplin-cli files

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -69,7 +69,6 @@ package() {
   cp -R "${srcdir}/${pkgname}-${pkgver}/ElectronClient/app/dist/linux-unpacked/"* \
     "${pkgdir}/usr/share/${pkgname}"
 
-
   cd ${srcdir}
   install -m755 joplin-desktop.sh "${pkgdir}/usr/bin/joplin-desktop"
   install -m755 joplin.sh "${pkgdir}/usr/bin/joplin"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -66,8 +66,6 @@ package() {
     "${pkgdir}/usr/share/${pkgname}-cli"
   cp -R "${srcdir}/${pkgname}-${pkgver}/CliClient/node_modules" \
     "${pkgdir}/usr/share/${pkgname}-cli"
-  rm -r "${pkgdir}/usr/share/${pkgname}-cli/"
-  # usr/share/joplin/resources/app/node_modules/sqlite3/.vscode
   cp -R "${srcdir}/${pkgname}-${pkgver}/ElectronClient/app/dist/linux-unpacked/"* \
     "${pkgdir}/usr/share/${pkgname}"
 


### PR DESCRIPTION
Hi, thank you for the packaging.

I had just the following problem while running joplin-cli:
```
$ joplin
Cannot find /usr/share/joplin-cli/
```

I looked over the PKGBUILD file and it worked for me without the line 69.
I may be wrong, I'm a newbie at aur package building.