### PR TITLE
Fixed build.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -43,8 +43,6 @@ build() {
   # Electron App
   cd "${srcdir}/${pkgname}-${pkgver}/ElectronClient"
   npm install --cache "${srcdir}/npm-cache"
-  yarn dist
-
 }
 
 package() {


### PR DESCRIPTION
The line "yarn dist" broke the latest build.
I checked the [package.json](https://github.com/laurent22/joplin/blob/master/package.json) file and did not see a dist script.
I guess this line was left by mistake.