### PR TITLE
Use npm run dist instead of yarn dist.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -43,7 +43,7 @@ build() {
   # Electron App
   cd "${srcdir}/${pkgname}-${pkgver}/ElectronClient"
   npm install --cache "${srcdir}/npm-cache"
-  yarn dist
+  npm run dist
 
 }
 


### PR DESCRIPTION
If you don't have yarn installed on the local machine, the build breaks.
Please use npm instead.