### PR TITLE
upgpkg: joplin 3.0.15-1

### DIFF
--- a/joplin/.SRCINFO
+++ b/joplin/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = joplin
-	pkgver = 3.0.14
+	pkgver = 3.0.15
 	pkgrel = 1
 	url = https://joplinapp.org/
 	install = joplin.install
@@ -33,7 +33,7 @@ pkgbase = joplin
 	source = joplin.desktop
 	source = joplin-desktop.sh
 	source = joplin.sh
-	source = joplin-3.0.14.tar.gz::https://github.com/laurent22/joplin/archive/v3.0.14.tar.gz
+	source = joplin-3.0.15.tar.gz::https://github.com/laurent22/joplin/archive/v3.0.15.tar.gz
 	sha256sums = c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2
 	sha256sums = a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8
 	sha256sums = b6a8361cbc59e7dbc33bcc427274efb945d8d654bf013b12c7021be681f568e2

--- a/joplin/PKGBUILD
+++ b/joplin/PKGBUILD
@@ -8,7 +8,7 @@
 
 pkgbase="joplin"
 pkgname=('joplin' 'joplin-desktop')
-pkgver=3.0.14
+pkgver=3.0.15
 groups=('joplin')
 pkgrel=1
 install="joplin.install"
@@ -23,7 +23,7 @@ source=("joplin.desktop" "joplin-desktop.sh" "joplin.sh"
 sha256sums=('c7c5d8b0ff9edb810ed901ea21352c9830bfa286f3c18b1292deca5b2f8febd2'
             'a450284fe66d89aa463d129ce8fff3a0a1a783a64209e4227ee47449d5737be8'
             'b6a8361cbc59e7dbc33bcc427274efb945d8d654bf013b12c7021be681f568e2'
-            '1f068ac5bfdee5e4d6f1f1d44a23f08d5536e503cbae90c33ea56c3c0a7fa99c')
+            '518fd9f07d6a5e255bfb990bce4af30322ac2a3c9c4cdb4276f95110a31ddb91')
 
 # local npm cache directory
 _yarn_cache="yarn-cache"


### PR DESCRIPTION
Since someone marked this as outdated in the AUR.

Tested via:

```
CHROOT=/mnt/large/cache/chroot
export CHROOT
mkdir -p "${CHROOT}"
mkarchroot "$CHROOT/root" base-devel

arch-nspawn "${CHROOT}/root" pacman -Syu --noconfirm \
            git \
            npm \
            yarn \
            python \
            rsync \
            jq \
            yq \
            electron \
            libgsf \
            node-gyp>=9.4.1 \
            python-setuptools \
            libexif \
            libwebp \
            libxss \
            orc
makechrootpkg -c -r $CHROOT
```

buildlog:  [buildlog.txt](https://github.com/user-attachments/files/17004269/buildlog.txt)

This was a pretty straightforward upgrade.